### PR TITLE
Metadata2csv updates

### DIFF
--- a/scripts/metadata2csv.py
+++ b/scripts/metadata2csv.py
@@ -45,22 +45,21 @@ def main():
         # Process the file
         with open(filepath) as f:
             initial_timestamp = None
-            dialog = []
+            dialogs = []
 
             for line in f:
+                message = json.loads(line)
                 # grab the timestamp for the trial start
-                if '"sub_type":"start"' in line or '"sub_type": "start"' in line:
-                    initial_timestamp = json.loads(line)["msg"]["timestamp"]
+                if message["topic"] == "trial" and message["msg"]["sub_type"] == "start":
+                    initial_timestamp = message["msg"]["timestamp"]
 
                 # after grabbing initial timestamp,
                 # find all transcribed utterances
                 if initial_timestamp is not None:
-                    message = json.loads(line)
                     # we want the asr transcriptioins
                     # with topic agent/asr/final
                     if (
-                        message["msg"]["sub_type"] == "asr:transcription"
-                        and message["topic"] == "agent/asr/final"
+                        message["topic"] == "agent/asr/final"
                     ):
                         data = message["data"]
 
@@ -84,12 +83,12 @@ def main():
                         participant_id = data["participant_id"]
 
                         # add these items to the dialog
-                        dialog.append(
+                        dialogs.append(
                             [msg_id, participant_id, text, relative_start, relative_end]
                         )
 
         # convert dialog to pandas df
-        df = pd.DataFrame(dialog)
+        df = pd.DataFrame(dialogs)
 
         # ignore empty dataframes
         if len(df) == 0:

--- a/scripts/metadata2csv.py
+++ b/scripts/metadata2csv.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Example usage
 # -------------
 #

--- a/scripts/metadata2csv.py
+++ b/scripts/metadata2csv.py
@@ -6,7 +6,6 @@
 #   ./metadata2csv metadataDirectory csvDirectory
 
 
-import sys
 import os
 import json
 import pandas as pd
@@ -14,6 +13,7 @@ from pathlib import Path
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from logging import warning
+
 
 def main():
     from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
@@ -23,16 +23,15 @@ def main():
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
 
-    parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
-
-    parser.add_argument("dir_path", type=str, nargs="+", help="Input .metadata files directory location")
+    parser.add_argument(
+        "dir_path", type=str, nargs="+", help="Input .metadata files directory location"
+    )
     args = parser.parse_args()
 
     dir_path = args.dir_path[0]
     new_dir = args.dir_path[1]
-    # print("dir_path ", dir_path)
-    # print("new_path ", new_dir)
-    if not os.path.isdir(new_dir): 
+
+    if not os.path.isdir(new_dir):
         os.makedirs(new_dir)
     filenames = os.listdir(dir_path)
     for filename in filenames:
@@ -40,55 +39,76 @@ def main():
 
         # Parse the filename components
         path = Path(filepath)
-        trial=filepath.rpartition("Trial-")[2].split("_")[0]
-        team=str(int(filepath.rpartition("Team-")[2].split("_")[0][2:]))
-        condbtwn=filepath.rpartition("CondBtwn-")[2].split("_")[0]
-        condwin=filepath.rpartition("CondWin-")[2].split("_")[0]
+        trial = filepath.rpartition("Trial-")[2].split("_")[0]
+        team = str(int(filepath.rpartition("Team-")[2].split("_")[0][2:]))
+        condbtwn = filepath.rpartition("CondBtwn-")[2].split("_")[0]
+        condwin = filepath.rpartition("CondWin-")[2].split("_")[0]
 
         # Process the file
         with open(filepath) as f:
             initial_timestamp = None
             dialog = []
-            i=0
+
             for line in f:
-                # We are only interested in the final transcriptions, not the
-                # intermediate ones.
+                # grab the timestamp for the trial start
                 if '"sub_type":"start"' in line:
                     initial_timestamp = json.loads(line)["msg"]["timestamp"]
 
-                if "asr/final" in line or "userspeech" in line:
+                # after grabbing initial timestamp,
+                # find all transcribed utterances
+                if initial_timestamp is not None:
                     message = json.loads(line)
-                    data = message["data"]
-                    timestamp = message["msg"]["timestamp"]
+                    # we want the asr transcriptioins
+                    # with topic agent/asr/final
+                    if (
+                        message["msg"]["sub_type"] == "asr:transcription"
+                        and message["topic"] == "agent/asr/final"
+                    ):
+                        data = message["data"]
 
-                    timedelta = relativedelta(parse(timestamp), parse(initial_timestamp))
-                    relative_timestamp = f"{timedelta.minutes}:{timedelta.seconds}"
-                    
-                    if "text" in data:
+                        # calculate start timestamp
+                        start_time = data["start_timestamp"]
+                        startdelta = relativedelta(
+                            parse(start_time), parse(initial_timestamp)
+                        )
+                        relative_start = f"{startdelta.minutes}:{startdelta.seconds}"
+
+                        # calculate end timestamp
+                        end_time = data["end_timestamp"]
+                        enddelta = relativedelta(
+                            parse(end_time), parse(initial_timestamp)
+                        )
+                        relative_end = f"{enddelta.minutes}:{enddelta.seconds}"
+
+                        # get the text, utt id, and participant id
                         text = data["text"]
-                        if text == "": i=0
-                    else: text = ""
-                    if "asr/final" in line and "participant_id" in data:
+                        msg_id = data["id"]
                         participant_id = data["participant_id"]
-                    elif "userspeech" in line and "playername" in data:
-                        participant_id = data["playername"]
-                    else: participant_id = ""
-                    trial_uuid = message["msg"]["trial_id"]
-                    if i%2 == 0 and text != "":
-                        dialog.append([participant_id, text, relative_timestamp])
-                    i+=1
 
-        
+                        # add these items to the dialog
+                        dialog.append(
+                            [msg_id, participant_id, text, relative_start, relative_end]
+                        )
 
+        # convert dialog to pandas df
         df = pd.DataFrame(dialog)
-        df.columns = ["participant", "utt", "start_timestamp"]
-        df["end_timestamp"] = ""
-        df["corr_utt"] = ""
-        filename = filename.split(".")[0]
-        new_file_path = os.path.join(new_dir, filename+"_correctedTranscripts.csv")
-        df.to_csv(new_file_path, index = False)
 
-    
+        # add colnames and empty col
+        # for manual transcript correction
+        df.columns = [
+            "message_id",
+            "participant",
+            "utt",
+            "start_timestamp",
+            "end_timestamp",
+        ]
+        df["corr_utt"] = ""
+
+        # save this csv
+        filename = filename.split(".")[0]
+        new_file_path = os.path.join(new_dir, filename + "_correctedTranscripts.csv")
+        df.to_csv(new_file_path, index=False)
+
+
 if __name__ == "__main__":
     main()
-    

--- a/scripts/metadata2csv.py
+++ b/scripts/metadata2csv.py
@@ -49,7 +49,7 @@ def main():
 
             for line in f:
                 # grab the timestamp for the trial start
-                if '"sub_type":"start"' in line:
+                if '"sub_type":"start"' in line or '"sub_type": "start"' in line:
                     initial_timestamp = json.loads(line)["msg"]["timestamp"]
 
                 # after grabbing initial timestamp,
@@ -91,21 +91,25 @@ def main():
         # convert dialog to pandas df
         df = pd.DataFrame(dialog)
 
-        # add colnames and empty col
-        # for manual transcript correction
-        df.columns = [
-            "message_id",
-            "participant",
-            "utt",
-            "start_timestamp",
-            "end_timestamp",
-        ]
-        df["corr_utt"] = ""
+        # ignore empty dataframes
+        if len(df) == 0:
+            warning(f"File {filepath} failed")
+        else:
+            # add colnames and empty col
+            # for manual transcript correction
+            df.columns = [
+                "message_id",
+                "participant",
+                "utt",
+                "start_timestamp",
+                "end_timestamp",
+            ]
+            df["corr_utt"] = ""
 
-        # save this csv
-        filename = filename.split(".")[0]
-        new_file_path = os.path.join(new_dir, filename + "_correctedTranscripts.csv")
-        df.to_csv(new_file_path, index=False)
+            # save this csv
+            filename = filename.split(".")[0]
+            new_file_path = os.path.join(new_dir, filename + "_correctedTranscripts.csv")
+            df.to_csv(new_file_path, index=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updated metadata2csv script to:
- use only `asr:transcription` messages
- load lines with json rather than completing string search
- include utterance IDs in the csv output
- calculate relative end timestamp in addition to start timestamp